### PR TITLE
Disable language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* linguist-detectable=false


### PR DESCRIPTION
Right now, the entire Tides of Europe repository is marked as ShaderLab, GLSL, HLSL, etc. This commit disables language detection by modifying `.gitattributes`.

I've tested this on the command line with the GitHub Linguist CLI tool.